### PR TITLE
Fix output truncations and bad mantissa calculation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.61])
-AC_INIT([growlight], [1.0.6.1], [sprezzos-dev@sprezzatech.com], [growlight], [https://nick-black.com/dankwiki/index.php/Growlight])
+AC_INIT([growlight], [1.0.6.2], [dankamongmen@gmail.com], [growlight], [https://nick-black.com/dankwiki/index.php/Growlight])
 AC_CONFIG_AUX_DIR([.])
 AM_INIT_AUTOMAKE([-Wall foreign dist-xz std-options subdir-objects nostdinc color-tests])
 AC_CONFIG_HEADER([src/config.h])

--- a/src/growlight.h
+++ b/src/growlight.h
@@ -453,9 +453,17 @@ genprefix(uintmax_t val,unsigned decimal,char *buf,size_t bsize,
 	if(dv != mult){
 		dv /= mult;
 		val /= decimal;
-		if((val % dv) / ((dv + 99) / 100) || omitdec == 0){
-			snprintf(buf,bsize,"%ju.%02ju%c%c",val / dv,(val % dv) / ((dv + 99) / 100),
-					prefixes[consumed - 1],uprefix);
+		// Remainder is val % dv; we want a percentage as scaled integer
+		unsigned remain = (val % dv) * 100 / dv;
+		if(remain || omitdec == 0){
+			// FIXME we throw the % 100 on remain to avoid a
+			// format-truncation warning. remain ought always be
+			// less than 100, since integer division goes to 0.
+			snprintf(buf, bsize,"%ju.%02u%c%c",
+					val / dv,
+					remain % 100,
+					prefixes[consumed - 1],
+					uprefix);
 		}else{
 			snprintf(buf,bsize,"%ju%c%c",val / dv,prefixes[consumed - 1],uprefix);
 		}

--- a/src/ncurses.c
+++ b/src/ncurses.c
@@ -1188,9 +1188,14 @@ case LAYOUT_NONE:
 				assert(wattrset(rb->win,COLOR_PAIR(OPTICAL_COLOR)) == OK);
 				strncpy(rolestr,"removable",sizeof(rolestr));
 			}else if(bo->d->blkdev.rotation >= 0){
+				int32_t speed = bo->d->blkdev.rotation;
 				assert(wattrset(rb->win,COLOR_PAIR(ROTATE_COLOR)) == OK);
-				if(bo->d->blkdev.rotation > 0){
-					snprintf(rolestr,sizeof(rolestr),"%d rpm",bo->d->blkdev.rotation);
+				if(speed > 0){
+					if(speed > 99999){
+						speed = 99999;
+					}
+					snprintf(rolestr, sizeof(rolestr),
+						 "%d rpm", speed);
 				}else{
 					strncpy(rolestr,"ferromag",sizeof(rolestr));
 				}
@@ -1227,7 +1232,8 @@ case LAYOUT_NONE:
 		break;
 case LAYOUT_MDADM:
 		if(bo->d->mddev.level){
-			strncpy(rolestr,bo->d->mddev.level,sizeof(rolestr));
+			strncpy(rolestr, bo->d->mddev.level, sizeof(rolestr) - 1);
+			rolestr[sizeof(rolestr) - 1] = '\0';
 		}
 		if(bo->d->mddev.degraded){
 			co = COLOR_PAIR(FUCKED_COLOR);


### PR DESCRIPTION
* genprefix() calculated the mantissa a bit incorrectly (#16 )
* work around -Wformat-truncation warnings where incorrect (#10), fix one actual bug, thanks gcc!
