### PR TITLE
UI fixes for 1.1.1

### DIFF
--- a/src/ncurses.c
+++ b/src/ncurses.c
@@ -4952,14 +4952,14 @@ select_adapter(void){
 		return -1;
 	}
 	if(rb->selected){
-		locked_diag("Already browsing [%s]",rb->as->c->ident);
+		// locked_diag("Already browsing [%s]", rb->as->c->ident);
 		return 0;
 	}
 	if(rb->as->bobjs == NULL){
 		return -1;
 	}
 	assert(rb->selline == -1);
-	return select_adapter_dev(rb,rb->as->bobjs,2);
+	return select_adapter_dev(rb, rb->as->bobjs, 2);
 }
 
 static void


### PR DESCRIPTION
* Eliminate 'already browsing adapter' diagnostic; it was pointless (#29)
* Remember zone of visited adapters more accurately (#37)
* Recognize PCIe 4.0 (#36)